### PR TITLE
Add email reply editing UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
 # codex-test
+
+This repository contains a small example of an email assistant inspired by Pete Koomen's essay on AI-native software. The assistant processes a list of dummy emails and applies simple rules to label messages, draft short replies and optionally archive spam.
+
+## Command line usage
+
+Run the assistant with Python:
+
+```bash
+python3 email_assistant.py
+```
+
+The output shows the actions the agent would take for each email.
+
+## Web UI
+
+A minimal Flask app provides a simple interface with a "Go" button on the left and the processed emails on the right. Draft replies are generated for each email and you can edit them before hitting **Send**. Install Flask and run:
+
+```bash
+pip install Flask
+python3 web_app.py
+```
+
+Then open [http://localhost:5000](http://localhost:5000) in your browser.

--- a/email_assistant.py
+++ b/email_assistant.py
@@ -1,0 +1,73 @@
+from dataclasses import dataclass
+from typing import List, Tuple
+import re
+
+@dataclass
+class Email:
+    sender: str
+    subject: str
+    body: str
+
+# Dummy email data
+DUMMY_EMAILS: List[Email] = [
+    Email(sender="Sumana <sumana@example.com>", subject="dinner tonight", body="Want to do dinner at home?"),
+    Email(sender="Garry Tan <garry@yc.com>", subject="reschedule", body="Need to reschedule our meeting."),
+    Email(sender="Alex Chen <alex@example.com>", subject="advice on fundraising", body="Can I get your thoughts on fundraising?"),
+    Email(sender="Gustaf Alstr\xf6mer <gustaf@yc.com>", subject="founder intro?", body="Have a founder you should meet."),
+    Email(sender="Maya Rodriguez <maya@example.com>", subject="Technical co-founder?", body="Know anyone interested in joining as CTO?"),
+    Email(sender="HackerNews Digest <news@hn.com>", subject="Top Stories: New Programming Languages", body="Lot's happening in tech this week."),
+    Email(sender="TechCrunch Weekly <newsletter@techcrunch.com>", subject="This Week in Tech: AI Developments and Market Trends", body="In this week's roundup we cover..."),
+    Email(sender="The Verge Updates <updates@theverge.com>", subject="Latest Product Launches and Industry News", body="Today in tech..."),
+    Email(sender="DevOps Pro Team <sales@devopspro.com>", subject="Security Solutions for Growing Companies", body="We have tools that will transform your workflow."),
+    Email(sender="DataAnalytics Plus <pricing@dap.com>", subject="Special Pricing on Data Analytics Tools", body="Exclusive offer inside."),
+    Email(sender="Sarah from SaaS Solutions <sarah@saassolutions.com>", subject="Exclusive Offer for New Customers", body="Get 20% off if you sign up now"),
+    Email(sender="Mark at Enterprise Tools <mark@enterprisetools.com>", subject="Transform Your Workflow with Our Platform", body="Our platform will increase productivity"),
+]
+
+class EmailAssistant:
+    """Simple rule-based assistant using Pete's labeling logic."""
+
+    def process_email(self, email: Email) -> List[Tuple[str, ...]]:
+        sender = email.sender.lower()
+        subject = email.subject.lower()
+        body = email.body.lower()
+        actions: List[Tuple[str, ...]] = []
+
+        if "sumana" in sender:
+            actions.append(("labelEmail", "Personal", "red", "0"))
+            actions.append(("draftReply", "sounds good -Pete"))
+        elif "garry" in sender:
+            actions.append(("labelEmail", "YC", "orange", "1"))
+            actions.append(("draftReply", "will do thx -Pete"))
+        elif "@yc.com" in sender:
+            actions.append(("labelEmail", "YC", "orange", "2"))
+            actions.append(("draftReply", "thanks will follow up -Pete"))
+        elif any(name in sender for name in ["alex", "maya", "gustaf"]):
+            actions.append(("labelEmail", "Founders", "blue", "2"))
+            actions.append(("draftReply", "happy to chat -Pete"))
+        elif any(word in subject for word in ["digest", "weekly", "updates"]):
+            actions.append(("labelEmail", "Tech", "gray", "3"))
+        elif any(word in body for word in ["exclusive", "pricing", "offer", "workflow"]):
+            actions.append(("archiveEmail",))
+        else:
+            actions.append(("labelEmail", "General", "gray", "3"))
+        return actions
+
+
+def main() -> None:
+    assistant = EmailAssistant()
+    for email in DUMMY_EMAILS:
+        print(f"---\nFrom: {email.sender}\nSubject: {email.subject}")
+        actions = assistant.process_email(email)
+        for act in actions:
+            if act[0] == "labelEmail":
+                _, label, color, priority = act
+                print(f"labelEmail(label={label}, color={color}, priority={priority})")
+            elif act[0] == "draftReply":
+                _, body = act
+                print(f"draftReply(body={body})")
+            elif act[0] == "archiveEmail":
+                print("archiveEmail()")
+
+if __name__ == "__main__":
+    main()

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,95 @@
+from flask import Flask, render_template_string, request, redirect, url_for
+from email_assistant import EmailAssistant, DUMMY_EMAILS
+
+app = Flask(__name__)
+assistant = EmailAssistant()
+
+HTML_PAGE = """
+<!doctype html>
+<html>
+<head>
+    <title>Email Assistant Demo</title>
+    <style>
+        body {font-family: Arial, sans-serif; margin: 40px;}
+        .container {display: flex;}
+        .left {margin-right: 20px;}
+        .emails {display: flex; flex-direction: column; gap: 20px; width: 70%;}
+        .email-card {border: 1px solid #ccc; padding: 15px; border-radius: 5px; background: #fafafa;}
+        .email-header {font-weight: bold; margin-bottom: 10px;}
+        textarea {width: 100%; height: 80px;}
+        .actions {margin-top: 10px;}
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="left">
+            <form method="post">
+                <button type="submit">Go</button>
+            </form>
+        </div>
+        <div class="emails">
+            {% for email in emails %}
+            <div class="email-card">
+                <div class="email-header">{{ email.sender }} &ndash; {{ email.subject }}</div>
+                <div class="email-body">{{ email.body }}</div>
+                {% if email.sent %}
+                <em>Sent!</em>
+                {% elif email.draft %}
+                <form method="post" action="{{ url_for('send', index=loop.index0) }}">
+                    <textarea name="reply">{{ email.draft }}</textarea>
+                    <div class="actions">
+                        <button type="submit">Send</button>
+                    </div>
+                </form>
+                {% elif email.archived %}
+                <em>Archived</em>
+                {% endif %}
+            </div>
+            {% endfor %}
+            {% if not emails %}
+                <p>Press Go to process emails.</p>
+            {% endif %}
+        </div>
+    </div>
+</body>
+</html>
+"""
+
+processed_emails = []
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    global processed_emails
+    if request.method == 'POST':
+        processed_emails = []
+        for email in DUMMY_EMAILS:
+            actions = assistant.process_email(email)
+            entry = {
+                'sender': email.sender,
+                'subject': email.subject,
+                'body': email.body,
+                'draft': None,
+                'archived': False,
+                'sent': False,
+            }
+            for act in actions:
+                if act[0] == 'draftReply':
+                    entry['draft'] = act[1]
+                elif act[0] == 'archiveEmail':
+                    entry['archived'] = True
+            processed_emails.append(entry)
+    return render_template_string(HTML_PAGE, emails=processed_emails)
+
+
+@app.route('/send/<int:index>', methods=['POST'])
+def send(index: int):
+    global processed_emails
+    if 0 <= index < len(processed_emails):
+        processed_emails[index]['draft'] = request.form.get('reply', '')
+        processed_emails[index]['sent'] = True
+        # placeholder for sending logic
+    return redirect(url_for('index'))
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- expand Flask UI for processing emails
- show editable draft replies with a Send button
- clarify README instructions for the web app

## Testing
- `python3 email_assistant.py | head -n 20`
- `pip install flask`
- `python3 web_app.py` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6840c8d17118832286bdc4b45b72fa4d